### PR TITLE
Fixed bug in json.hpp: it was not checking last.m_object, fixed a couple of minor mem leaks

### DIFF
--- a/bus.cpp
+++ b/bus.cpp
@@ -16,8 +16,9 @@ using namespace boost;
 using std::string;
 
 Bus::Bus(boost::shared_ptr<Server> server, string bindaddress)
-    : _server(server), _bindaddress(bindaddress) {
-  boost::thread *t = new boost::thread(boost::bind(&Bus::run, this));
+    : _server(server), _bindaddress(bindaddress),
+      t(new boost::thread(boost::bind(&Bus::run, this)))
+{
 }
 
 void Bus::reload(string subdomain) {

--- a/bus.h
+++ b/bus.h
@@ -9,6 +9,7 @@
 class Bus {
   std::string _bindaddress;
   boost::shared_ptr<Server> _server;
+  boost::shared_ptr<boost::thread> t;
 
   void reload(std::string subdomain);
 

--- a/json.hpp
+++ b/json.hpp
@@ -6564,7 +6564,7 @@ class serializer
                         // check that the additional bytes are present
                         assert(i + bytes < s.size());
 
-                        // to use \uxxxx escaping, we first need to caluclate
+                        // to use \uxxxx escaping, we first need to caluclate
                         // the codepoint from the UTF-8 bytes
                         int codepoint = 0;
 
@@ -12292,7 +12292,7 @@ class basic_json
 
         // passed iterators must belong to objects
         if (JSON_UNLIKELY(not first.m_object->is_object()
-                          or not first.m_object->is_object()))
+                          or not last.m_object->is_object()))
         {
             JSON_THROW(invalid_iterator::create(202, "iterators first and last must point to objects"));
         }

--- a/query.cpp
+++ b/query.cpp
@@ -49,6 +49,7 @@ Query::Query(Site *s, Context *context, const string &q) : site(s), xpathObj(NUL
   }
   if (pcrecpp::RE("([0-9]+)(/.*|)").FullMatch(query, &id, &query)) {
     find(atoi(id.c_str()));
+    // WARNING: size is used, but not initialized, it maybe arbitrary value
     if (size && (query.length() > 0)) {
       context = (Context *)getNode(0)->_private;
       if (xpathObj != NULL) {

--- a/reaper.cpp
+++ b/reaper.cpp
@@ -18,8 +18,9 @@ using namespace std;
 #include "server.h"
 #include "session.h"
 
-Reaper::Reaper(Server *h, MysqlProxy &p) : server(h), mysqlProxy(p) {
-  boost::thread *t = new boost::thread(boost::bind(&Reaper::Run, this));
+Reaper::Reaper(Server *h, MysqlProxy &p) : server(h), mysqlProxy(p),
+    t(new boost::thread(boost::bind(&Reaper::Run, this)))
+{
 }
 
 void Reaper::Run() {

--- a/reaper.h
+++ b/reaper.h
@@ -4,6 +4,7 @@ class Reaper {
 
   class Server *server;
   MysqlProxy &mysqlProxy;
+  boost::shared_ptr<boost::thread> t;
 
  public:
    Reaper(class Server *h, MysqlProxy &p);


### PR DESCRIPTION
Fixed bug in json.hpp: it was not checking last.m_object
Fixed two minor memory leaks in bus.cpp and query.cpp, not too important
though.
And need to watch on my WARNING comment about uninitialized size variable in query.cpp
Below is a first screenshot is valgrind output before fixes
![screenshot from 2018-01-15 00-17-02](https://user-images.githubusercontent.com/284653/34920164-2d9ad526-f990-11e7-88c0-ec8150de32e8.png)

 and the second one is after fixes.
![screenshot from 2018-01-15 00-59-40](https://user-images.githubusercontent.com/284653/34920165-30a71978-f990-11e7-856d-0caf49cd5bfb.png)

I saw a bid request in upwork about memory leaks and I did a proposal (not finished), but accidentally click "send" without finishing my text. So, I will write it here.
I ran the vae_remote tests several times and didn't see any memory leak raising on vaedb. There are a couple of minor memory leaks about 1mb and 0.5mb which don't grow over time. Is this the only issue or there is something another?
You can find my bid in upwork.
Regards,
Dilshod <dilshodm at gmail.com>
